### PR TITLE
flag option changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,7 @@ checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "rusty-roots"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rusty-roots"
-version = "0.2.2"
+version = "0.3.0"
 edition = "2021"
 description = "A Rust CLI tool that replicates the Unix 'tree' command with enhanced features."
 license = "MIT"

--- a/Cargo_README.md
+++ b/Cargo_README.md
@@ -26,11 +26,11 @@ rusty-roots
 Usage: rusty-roots [OPTIONS]
 
 Options:
-  -p, --path <PATH>     Path to get tree from
-  -i, --ignore          Ignore files and directories as specified in {$path}/.rrignore
-      --no-color        Do not stylize tree text output
-  -h, --help            Print help
-  -V, --version         Print version
+  -p, --path <PATH>  Path to get tree from
+  -i, --ignore       Ignore files and directories as specified in {$path}/.rrignore
+  -f, --fast-print   Print directory on the fly without pre-calculation
+  -h, --help         Print help
+  -V, --version      Print version
 ```
 
-*tip: If the program seems to be hanging because the called directory is extremely large, try running with `--no-color`. Pre-calculation for the branch color gradient is not done when this flag is called, so the program will print the tree on-the-fly.* 
+*tip: If the program seems to be hanging because the called directory is extremely large, try running with `-f`. Pre-calculation for the branch color gradient is not done when this flag is called, so the program will be able to print the tree on-the-fly.* 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ rusty-roots
 Usage: rusty-roots [OPTIONS]
 
 Options:
-  -p, --path <PATH>     Path to get tree from
-  -i, --ignore          Ignore files and directories as specified in {$path}/.rrignore
-      --no-color        Do not stylize tree text output
-  -h, --help            Print help
-  -V, --version         Print version
+  -p, --path <PATH>  Path to get tree from
+  -i, --ignore       Ignore files and directories as specified in {$path}/.rrignore
+  -f, --fast-print   Print directory on the fly without pre-calculation
+  -h, --help         Print help
+  -V, --version      Print version
 ```
 
-*tip: If the program seems to be hanging because the called directory is extremely large, try running with `--no-color`. Pre-calculation for the branch color gradient is not done when this flag is called, so the program will print the tree on-the-fly.* 
+*tip: If the program seems to be hanging because the called directory is extremely large, try running with `-f`. Pre-calculation for the branch color gradient is not done when this flag is called, so the program will be able to print the tree on-the-fly.* 

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 use globset::GlobSet;
 
 use crate::ignore::load_ignore_patterns;
-use crate::text_fmt::{color_branch, color_path, get_path_end};
+use crate::text_fmt::{color_branch, color_path};
 
 type DirectoryBody = HashMap<PathBuf, Vec<PathBuf>>;
 
@@ -166,7 +166,7 @@ impl Directory {
             }
         }
         print!("{}", pos);
-        print!("{}", get_path_end(cur));
+        print!("{}", color_path(cur));
 
         // update wall list for next call (add to stack)
         wall_list.push(pos != LAST_CHILD);

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,26 +22,27 @@ fn main() {
                 .help("Ignore files and directories as specified in {$path}/.rrignore"),
         )
         .arg(
-            Arg::new("no-color")
-                .long("no-color")
+            Arg::new("fast-print")
+                .short('f')
+                .long("fast-print")
                 .action(clap::ArgAction::SetTrue)
-                .help("Do not stylize tree text output"),
+                .help("Print directory on the fly without pre-calculation"),
         )
         .get_matches();
 
     let input_path = matches.get_one::<String>("path");
     let ignore = matches.get_flag("ignore");
-    let color = !matches.get_flag("no-color");
+    let fp = matches.get_flag("fast-print");
     let target_path = match input_path {
         Some(s) => Path::new(s),
         None => Path::new("."),
     };
 
-    if color {
-        let dir = Directory::new(target_path, ignore).unwrap();
-        dir.print_body().unwrap();
-    } else {
+    if fp {
         let dir = Directory::new_with_empty_body(target_path, ignore).unwrap();
         dir.fast_print_body().unwrap();
+    } else {
+        let dir = Directory::new(target_path, ignore).unwrap();
+        dir.print_body().unwrap();
     }
 }

--- a/tests/test_modes.sh
+++ b/tests/test_modes.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# testing no flags vs --no-color (fast print) outputs
+# testing no flags vs --fast-print outputs
 
 # vars
 test_dir="test_tree"
@@ -36,7 +36,7 @@ touch $test_dir/subdir4/subsubdir7/file16.txt
 # run expected and observed
 mkdir $test_output_dir
 ../target/release/rusty-roots -p $test_dir > $test_output_dir/og_output.txt
-../target/release/rusty-roots --no-color -p $test_dir > $test_output_dir/no_color_output.txt
+../target/release/rusty-roots --fast-print -p $test_dir > $test_output_dir/no_color_output.txt
 
 # compare
 diff $test_output_dir/og_output.txt $test_output_dir/no_color_output.txt


### PR DESCRIPTION
**addressing issue #3**

Removed `--no-color` since it's not that useful imo. Replaced with --fast-print, which still will color filepaths but print on-the-fly instead of pre-calculating like default.